### PR TITLE
Add Fade-In background color option

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ var SomeComponent = React.createClass({
 - `modalVisible` (Boolean) - Decide if the component should be visible or not.
 - `onCancel` (Function) - Function to run when the cancel button/background has been pressed.
 - `buttonText` (String) - The text of the onCancel button. Defaults to Cancel.
+- `backgroundColor` (String) - The color of the fade-in effect background. Defaults to 'black'.
 
 
 ### Questions/Bugs/Ideas?

--- a/fade_in_view.js
+++ b/fade_in_view.js
@@ -20,7 +20,10 @@ var FadeInView = React.createClass({
 
   render: function() {
     return (
-      <Animated.View style={[styles.overlay, {opacity: this.state.fadeAnim}]}>
+      <Animated.View style={[styles.overlay,
+          {opacity: this.state.fadeAnim},
+          {backgroundColor: this.props.backgroundColor || 'black' }
+        ]}>
         {this.props.children}
       </Animated.View>
     );
@@ -35,7 +38,6 @@ var styles = StyleSheet.create({
     right: 0,
     height: window.height,
     width: window.width,
-    backgroundColor: 'black',
     position: 'absolute'
   }
 });

--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ var { Modal, StyleSheet, TouchableOpacity, View} = React;
 var ActionModal = React.createClass({
   render: function() {
     return (
-      <FadeInView visible={this.props.modalVisible}>
+      <FadeInView visible={this.props.modalVisible} backgroundColor={this.props.backgroundColor}>
         <Modal
           animated={true}
           transparent={true}


### PR DESCRIPTION
When the modal is placed in a nested view, rather than a top-level view, it only takes up the space of the nested view. Also, padding styles of parent views are affecting the effect. I have not tried to see if this can be fixed yet, but changing the background color of the effect is one approach. On following example, the action sheet is placed in a Dropbox component, and several Dropboxes within a view.  See the screenshots for the described effect.

With default black background:

![screen shot 2016-02-24 at 16 30 27](https://cloud.githubusercontent.com/assets/2336352/13292523/08a197a6-db14-11e5-9ce8-e8f6458b25ec.png)

With overridden background: 

![screen shot 2016-02-24 at 16 30 57](https://cloud.githubusercontent.com/assets/2336352/13292527/0a2ca174-db14-11e5-91d2-e543f1db50fd.png)
