### PR TITLE
RN26, modal animated property deprecated

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ var ActionModal = React.createClass({
     return (
       <FadeInView visible={this.props.modalVisible} backgroundColor={this.props.backgroundColor}>
         <Modal
-          animated={true}
+          animationType="slide"
           transparent={true}
           visible={this.props.modalVisible}
           onRequestClose={this.props.onCancel}>


### PR DESCRIPTION
Getting deprecation warning on RN26 for animation property on Modal.

https://facebook.github.io/react-native/docs/modal.html#animationtype
